### PR TITLE
Dockerfile: use latest redpanda

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 # set this to the desired release
 # you will also need to download the tgz,
 # and possibly add packages if you change this
-ENV REDPANDA_RELEASE=20.11.4
+ENV REDPANDA_RELEASE=v21.4.12
 
 RUN apt -qy update \
  && apt -qy install \


### PR DESCRIPTION
Additionally: we also publish containers here: 
https://vectorized.io/docs/quick-start-docker

I noticed in your tests there were some issues w/ the consumer groups, and we'd love to track it. But this should get you testing the latest release fairly easily.

(if you run into issues like this, I'd love to help real time at vectorized.io/slack or in our github discussions)